### PR TITLE
Dodana namestitev knjižnice jcolors

### DIFF
--- a/install.R
+++ b/install.R
@@ -12,3 +12,5 @@
 #    "numDeriv",
 #    "rootSolve"
 #))
+
+install.packages("jcolors")


### PR DESCRIPTION
Za delovanje na Binderju (kot opozorjeno v #3) je potrebno poskrbeti za namestitev knjižnice `jcolors`. Osnovne slike žal ne morem posodobiti, tako da sem dodal nameščanje v `install.R`. Da sprejmeš ta pull request, ga torej odpri na GitHubu in klikni na **Merge pull request**, nato pa pri sebi naredi *pull*, da pridobiš spremembe. 